### PR TITLE
CategorySeederを修正しました。

### DIFF
--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -18,6 +18,7 @@ class CategoryFactory extends Factory
     public function definition(): array
     {
         return [
+            'name' => $this->faker->randomElement(['仕事', 'プライベート', 'その他']),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -18,7 +18,6 @@ class CategoryFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->randomElement(['仕事','プライベート','その他']),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Category;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 
 class CategorySeeder extends Seeder
@@ -13,6 +14,13 @@ class CategorySeeder extends Seeder
      */
     public function run(): void
     {
-        Category::factory()->count(3)->create();
+        Category::factory()
+            ->count(3)
+            ->state(new Sequence(
+                ['name' => '仕事'],
+                ['name' => 'プライベート'],
+                ['name' => 'その他']
+            ))
+            ->create();
     }
 }


### PR DESCRIPTION
### CategorySeeder
・nameの値を順番に設定

### CategoryFactory
・name削除

db:seed実行時にcategoriesテーブルのname属性に仕事、プライベート、その他が順番に設定されるように修正しました。
確認お願いいたします。